### PR TITLE
DNA: Use Jetpack autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,8 @@
         "automattic/jetpack-logo": "1.1.0"
     },
     "require-dev": {
-        "automattic/jetpack-standards": "master-dev"
-    }
+        "automattic/jetpack-standards": "master-dev",
+        "automattic/jetpack-autoloader": "1.0.0"
+    },
+
 }

--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,4 @@
         "automattic/jetpack-standards": "master-dev",
         "automattic/jetpack-autoloader": "1.0.0"
     }
-
 }

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,6 @@
     "require-dev": {
         "automattic/jetpack-standards": "master-dev",
         "automattic/jetpack-autoloader": "1.0.0"
-    },
+    }
 
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,11 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
+<<<<<<< HEAD
     "content-hash": "906d05621f125dc5854e38b812ae1440",
+=======
+    "content-hash": "012bde1b46057ba55f0d5a9d87fa20fa",
+>>>>>>> 062de86... update composer lock
     "packages": [
         {
             "name": "automattic/jetpack-logo",
@@ -39,6 +43,39 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "automattic/jetpack-autoloader",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-autoloader.git",
+                "reference": "9e2016d791cad88842f8d501133653b70794e9d2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/9e2016d791cad88842f8d501133653b70794e9d2",
+                "reference": "9e2016d791cad88842f8d501133653b70794e9d2",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Autoloader\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Creates a custom autoloader for a plugin or theme.",
+            "time": "2019-06-11T16:14:45+00:00"
+        },
         {
             "name": "automattic/jetpack-standards",
             "version": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,11 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-<<<<<<< HEAD
-    "content-hash": "906d05621f125dc5854e38b812ae1440",
-=======
-    "content-hash": "012bde1b46057ba55f0d5a9d87fa20fa",
->>>>>>> 062de86... update composer lock
+    "content-hash": "6fec80cb77b31b953d57ee2aea8253c4",
     "packages": [
         {
             "name": "automattic/jetpack-logo",

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -20,7 +20,8 @@ defined( 'ABSPATH' ) or die();
  * We want to fail gracefully if `composer install` has not been executed yet, so we are checking for the autoloader.
  * If the autoloader is not present, let's log the failure, pause VaultPress, and display a nice admin notice.
  */
-$loader = dirname(__FILE__ ) . 'vendor/autoload_packages.php';
+$loader = plugin_dir_path(__FILE__ ) . 'vendor/autoload_packages.php';
+
 if ( is_readable( $loader ) ) {
 	require $loader;
 } else {

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -29,7 +29,7 @@ if ( is_readable( $autoloader ) ) {
 			wp_kses(
 				__( 'Your installation of VaultPress is incomplete. If you installed it from GitHub, please run <code>composer install</code>.', 'vaultpress' ),
 				array( 'code' => true )
-			);
+			)
 		);
 	}
 	/**

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -20,24 +20,28 @@ defined( 'ABSPATH' ) or die();
  * We want to fail gracefully if `composer install` has not been executed yet, so we are checking for the autoloader.
  * If the autoloader is not present, let's log the failure, pause VaultPress, and display a nice admin notice.
  */
-$loader = dirname( __FILE__ ) . '/vendor/autoload.php';
-if ( is_readable( $loader ) ) {
-	require $loader;
+$autoloader = dirname( plugin_basename( __FILE__ ) ) . 'vendor/autoload_packages.php';
+if ( is_readable( $autoloader ) ) {
+	require $autoloader;
 } else {
+	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		error_log(
+			__( 'Your installation of VaultPress is incomplete. If you installed it from GitHub, please run <code>composer install</code>.', 'vaultpress' )
+		);
+	}
+	/**
+	 * Outputs an admin notice for folks running VaultPress without having run `composer install`.
+	 */
+	function vaultpress_admin_missing_autoloader() { ?>
+        <div class="notice notice-error is-dismissible">
+            <p>
+				<?php _e( 'Your installation of VaultPress is incomplete. If you installed it from GitHub, please run <code>composer install</code>.', 'vaultpress' ); ?>
+            </p>
+        </div>
+		<?php
+	}
 	add_action( 'admin_notices', 'vaultpress_admin_missing_autoloader' );
 	return;
-}
-
-/**
- * Outputs an admin notice for folks running VaultPress without having run `composer install`.
- */
-function vaultpress_admin_missing_autoloader() { ?>
-	<div class="notice notice-error is-dismissible">
-		<p>
-			<?php _e( 'Your installation of VaultPress is incomplete. If you installed it from GitHub, please run <code>composer install</code>.', 'vaultpress' ); ?>
-		</p>
-	</div>
-	<?php
 }
 
 class VaultPress {

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -26,7 +26,10 @@ if ( is_readable( $autoloader ) ) {
 } else {
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		error_log(
-			__( 'Your installation of VaultPress is incomplete. If you installed it from GitHub, please run <code>composer install</code>.', 'vaultpress' )
+			wp_kses(
+				__( 'Your installation of VaultPress is incomplete. If you installed it from GitHub, please run <code>composer install</code>.', 'vaultpress' ),
+				array( 'code' => true )
+			);
 		);
 	}
 	/**

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) or die();
  * We want to fail gracefully if `composer install` has not been executed yet, so we are checking for the autoloader.
  * If the autoloader is not present, let's log the failure, pause VaultPress, and display a nice admin notice.
  */
-$loader = dirname( plugin_basename( __FILE__ ) ) . 'vendor/autoload_packages.php';
+$loader = dirname(__FILE__ ) . 'vendor/autoload_packages.php';
 if ( is_readable( $loader ) ) {
 	require $loader;
 } else {

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -39,7 +39,12 @@ if ( is_readable( $autoloader ) ) {
 		?>
 		<div class="notice notice-error is-dismissible">
 			<p>
-				<?php _e( 'Your installation of VaultPress is incomplete. If you installed it from GitHub, please run <code>composer install</code>.', 'vaultpress' ); ?>
+				<?php
+					echo wp_kses(
+						__( 'Your installation of VaultPress is incomplete. If you installed it from GitHub, please run <code>composer install</code>.', 'vaultpress' ),
+						array( 'code' => true )
+					);
+				?>
 			</p>
 		</div>
 		<?php

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -20,9 +20,9 @@ defined( 'ABSPATH' ) or die();
  * We want to fail gracefully if `composer install` has not been executed yet, so we are checking for the autoloader.
  * If the autoloader is not present, let's log the failure, pause VaultPress, and display a nice admin notice.
  */
-$autoloader = dirname( plugin_basename( __FILE__ ) ) . 'vendor/autoload_packages.php';
-if ( is_readable( $autoloader ) ) {
-	require $autoloader;
+$loader = dirname( plugin_basename( __FILE__ ) ) . 'vendor/autoload_packages.php';
+if ( is_readable( $loader ) ) {
+	require $loader;
 } else {
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		error_log(

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -32,12 +32,13 @@ if ( is_readable( $autoloader ) ) {
 	/**
 	 * Outputs an admin notice for folks running VaultPress without having run `composer install`.
 	 */
-	function vaultpress_admin_missing_autoloader() { ?>
-        <div class="notice notice-error is-dismissible">
-            <p>
+	function vaultpress_admin_missing_autoloader() {
+		?>
+		<div class="notice notice-error is-dismissible">
+			<p>
 				<?php _e( 'Your installation of VaultPress is incomplete. If you installed it from GitHub, please run <code>composer install</code>.', 'vaultpress' ); ?>
-            </p>
-        </div>
+			</p>
+		</div>
 		<?php
 	}
 	add_action( 'admin_notices', 'vaultpress_admin_missing_autoloader' );


### PR DESCRIPTION
Using jetpack-autoloader will prevent errors when running this plugin alongside Jetpack or any other plugin based on Jetpack packages.

**How to Test**

* Modify `composer.json` to require 1.0 of the Jetpack Logo package
* run `composer update`
* run `composer install`
* Active Vaultpress alongside Jetpack master in your test site
* Go to the Jetpack Dashboard and check that it loads without breakage(Jetpack Master requires a more up to date version of the Jetpack Logo package)




