### PR TITLE
Fix duplicated icon and bad layout for progress bars

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -556,13 +556,14 @@ Helpers
 	background-size: 300px 420px;
 }
 
-#no-access-credentials p {
+#vp-wrap #no-access-credentials p {
 	margin: 20px 0;
 	color: #333;
 	font-size: 14px;
 	text-shadow: 0 1px 0 rgba(255, 255, 255, 0.8);
 	text-align: left;
 	line-height: 1.4;
+	background: none;
 }
 
 @media only screen and (-moz-min-device-pixel-ratio: 1.5), only screen and (-o-min-device-pixel-ratio: 3, '/', 2), only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-device-pixel-ratio: 1.5) {
@@ -798,10 +799,6 @@ Tabs
 Progress Bars
 ========================================================================== */
 
-#vp_progress {
-	padding-right: 20px;
-}
-
 #vp_progress:after {
 	/* clearfix */
 	content: ".";
@@ -854,7 +851,6 @@ Progress Bars
 	}
 }
 
-
 .vp_graphs ul {
 	padding: 0 0 5px 0;
 	float: left;
@@ -879,6 +875,10 @@ Progress Bars
 	background: -webkit-linear-gradient(top, rgba(41,154,11,1) 0%,rgba(41,154,11,1) 100%);
 	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#299a0b', endColorstr='#299a0b',GradientType=0 );
 	background: linear-gradient(top, rgba(41,154,11,1) 0%,rgba(41,154,11,1) 100%);
+}
+
+#vp-wrap #vp_progress .vp_graphs ul li {
+	width: 100%;
 }
 
 #vp_progress .completed .percentage,
@@ -909,7 +909,6 @@ Progress Bars
 		width: 58%;
 	}
 }
-
 
 #vp_progress .bar span {
 	float: left;


### PR DESCRIPTION
Fixes #30 

Previously on Bad Layouts:

<img width="687" alt="Captura de Pantalla 2019-06-14 a la(s) 14 13 25" src="https://user-images.githubusercontent.com/1041600/59526176-aed29200-8eae-11e9-801d-036be265b9c8.png">

It's fixed now:

<img width="630" alt="Captura de Pantalla 2019-06-14 a la(s) 14 20 13" src="https://user-images.githubusercontent.com/1041600/59526559-93b45200-8eaf-11e9-8391-0ac421fd401c.png">

