### PR TITLE
Make spacing consistent in registration card

### DIFF
--- a/class-vaultpress.php
+++ b/class-vaultpress.php
@@ -590,11 +590,15 @@ class VaultPress {
 						<?php esc_html_e( 'Registration key', 'vaultpress' ) ?>
 					</div>
 					<div class="dops-card">
-						<p><?php _e( 'Paste your registration key&nbsp;below:', 'vaultpress' ); ?></p>
 						<form method="post" action="">
 							<fieldset>
-								<textarea class="dops-textarea" placeholder="<?php echo esc_attr( __( 'Enter your key here...', 'vaultpress' ) ); ?>" name="registration_key"></textarea>
-								<button class="dops-button"><?php _e( 'Register ', 'vaultpress' ); ?></button>
+								<p>
+									<?php esc_html_e( 'Paste your registration key&nbsp;below:', 'vaultpress' ); ?>
+								</p>
+								<p>
+									<textarea class="dops-textarea" placeholder="<?php esc_attr_e( __( 'Enter your key here...', 'vaultpress' ) ); ?>" name="registration_key"></textarea>
+								</p>
+								<button class="dops-button is-compact"><?php _e( 'Register ', 'vaultpress' ); ?></button>
 								<input type="hidden" name="action" value="register" />
 								<?php wp_nonce_field( 'vaultpress_register' ); ?>
 							</fieldset>
@@ -785,7 +789,7 @@ class VaultPress {
 					onsubmit="return confirm( '<?php esc_html_e( 'Do you really want to reset all options?', 'vaultpress' ) ?>' );"
 					method="post"
 					action="">
-					<button class="dops-button is-scary"><?php _e( 'Delete all VaultPress settings', 'vaultpress' ); ?></button>
+					<button class="dops-button is-scary is-compact"><?php esc_html_e( 'Delete all settings', 'vaultpress' ); ?></button>
 					<input type="hidden" name="action" value="delete-vp-settings"/>
 					<?php wp_nonce_field( 'delete_vp_settings' ); ?>
 				</form>


### PR DESCRIPTION
Fixes #26

Make space between text box and button consistent with the space between the text and the delete button in the other card.

The buttons are now compact, it wasn't necessary to have the big buttons.

The label of the button that deletes settings has been shorted.

<img width="584" alt="Captura de Pantalla 2019-06-14 a la(s) 19 14 03" src="https://user-images.githubusercontent.com/1041600/59541802-59f84100-8ed9-11e9-923a-3cdabda84c61.png">
