### PR TITLE
Notices: hook into a new vaultpress_notices hook in the VP dash.

### DIFF
--- a/class-vaultpress.php
+++ b/class-vaultpress.php
@@ -248,7 +248,14 @@ class VaultPress {
 		 * In the VaultPress dashboard when Jetpack is installed, move the notices.
 		 */
 		$screen = get_current_screen();
-		if ( ! is_null( $screen ) && in_array( $screen->id, array( 'jetpack_page_vaultpress', 'toplevel_page_vaultpress' ), true ) ) {
+		if (
+			! is_null( $screen )
+			&& in_array(
+				$screen->id,
+				array( 'jetpack_page_vaultpress', 'toplevel_page_vaultpress' ),
+				true
+			)
+		) {
 			$notice_hooks[] = 'vaultpress_notices';
 		} else {
 			$notice_hooks[] = 'admin_notices';

--- a/class-vaultpress.php
+++ b/class-vaultpress.php
@@ -237,29 +237,46 @@ class VaultPress {
 	}
 
 	function admin_head() {
-		if ( !current_user_can( 'manage_options' ) )
+		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
+		}
+
+		// Array of hooks where we want to hook our notices.
+		$notice_hooks = array( 'user_admin_notices' );
+
+		/*
+		 * In the VaultPress dashboard when Jetpack is installed, move the notices.
+		 */
+		$screen = get_current_screen();
+		if ( ! is_null( $screen ) && 'jetpack_page_vaultpress' === $screen->id ) {
+			$notice_hooks[] = 'vaultpress_notices';
+		} else {
+			$notice_hooks[] = 'admin_notices';
+		}
 
 		if ( $activated = $this->get_option( 'activated' ) ) {
 			if ( 'network' == $activated ) {
 				add_action( 'network_admin_notices', array( $this, 'activated_notice' ) );
 			} else {
-				foreach ( array( 'user_admin_notices', 'admin_notices' ) as $filter )
+				foreach ( $notice_hooks as $filter ) {
 					add_action( $filter, array( $this, 'activated_notice' ) );
+				}
 			}
 		}
 
 		// ask the user to connect their site w/ VP
 		if ( !$this->is_registered() ) {
-			foreach ( array( 'user_admin_notices', 'admin_notices' ) as $filter )
+			foreach ( $notice_hooks as $filter ) {
 				add_action( $filter, array( $this, 'connect_notice' ) );
+			}
 
 		// if we have an error make sure to let the user know about it
 		} else {
 			$error_code = $this->get_option( 'connection_error_code' );
-		 	if ( !empty( $error_code ) ) {
-				foreach ( array( 'user_admin_notices', 'admin_notices' ) as $filter )
+		 	if ( ! empty( $error_code ) ) {
+				foreach ( $notice_hooks as $filter ) {
 					add_action( $filter, array( $this, 'error_notice' ) );
+				}
 			}
 		}
 	}
@@ -405,6 +422,14 @@ class VaultPress {
 			<div id="jp-plugin-container">
 				<?php $this->ui_masthead( $ui_state[ 'dashboard_link' ] ); ?>
 				<div class="vp-wrap">
+					<?php
+					/**
+					 * Allow the display of custom notices.
+					 *
+					 * @since 2.0.0
+					 */
+					do_action( 'vaultpress_notices' );
+					?>
 					<?php echo $ui_state[ 'ui' ]; // This content is sanitized when it's produced. ?>
 				</div>
 				<?php $this->ui_footer(); ?>

--- a/class-vaultpress.php
+++ b/class-vaultpress.php
@@ -248,7 +248,7 @@ class VaultPress {
 		 * In the VaultPress dashboard when Jetpack is installed, move the notices.
 		 */
 		$screen = get_current_screen();
-		if ( ! is_null( $screen ) && 'jetpack_page_vaultpress' === $screen->id ) {
+		if ( ! is_null( $screen ) && in_array( $screen->id, array( 'jetpack_page_vaultpress', 'toplevel_page_vaultpress' ), true ) ) {
 			$notice_hooks[] = 'vaultpress_notices';
 		} else {
 			$notice_hooks[] = 'admin_notices';
@@ -745,13 +745,15 @@ class VaultPress {
 			}
 		}
 
+		$classes = in_array( get_current_screen()->parent_base, array( 'jetpack', 'vaultpress' ), true )
+			? ''
+			: "notice notice-$type";
+
 		$this->render_notice(
 			"<strong>$heading</strong><br/>$message",
 			$level,
 			array(),
-			'jetpack' !== get_current_screen()->parent_base
-				? "notice notice-$type"
-				: ''
+			$classes
 		);
 	}
 

--- a/class-vaultpress.php
+++ b/class-vaultpress.php
@@ -245,7 +245,7 @@ class VaultPress {
 		$notice_hooks = array( 'user_admin_notices' );
 
 		/*
-		 * In the VaultPress dashboard when Jetpack is installed, move the notices.
+		 * In the VaultPress dashboard, move the notices.
 		 */
 		$screen = get_current_screen();
 		if (


### PR DESCRIPTION
Avoid using the admin_notices hook to display notices in the new VP dashboard,
since that new dashboard expects notices to be displayed inside a custom container.

![image](https://user-images.githubusercontent.com/426388/60903840-fb20b000-a269-11e9-8fe5-5d76d24f2964.png)

**to test**

- Start from a site with Jetpack and VaultPress active.
- In VP MC, disable the plan.
- Load all admin pages, and make sure notices are displayed in the right place everywhere.