### PR TITLE
General: update version numbers to start 2.1 cycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "VaultPress",
-	"version": "2.0.0-beta",
+	"version": "2.1.0-alpha",
 	"description": "VaultPress is a subscription service offering real-time backup, automated security scanning, and support from WordPress experts.",
 	"homepage": "https://vaultpress.com",
 	"author": "Automattic",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, apokalyptik, briancolinger, josephscott, shaunandrews,
 Tags: security, malware, virus, archive, back up, back ups, backup, backups, scanning, restore, wordpress backup, site backup, website backup
 Requires at least: 5.1
 Tested up to: 5.2
-Stable tag: 2.0
+Stable tag: 2.0.1
 Requires PHP: 5.3
 License: GPLv2
 

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -3,7 +3,7 @@
  * Plugin Name: VaultPress
  * Plugin URI: http://vaultpress.com/?utm_source=plugin-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * Description: Protect your content, themes, plugins, and settings with <strong>realtime backup</strong> and <strong>automated security scanning</strong> from <a href="http://vaultpress.com/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0" rel="nofollow">VaultPress</a>. Activate, enter your registration key, and never worry again. <a href="http://vaultpress.com/help/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0" rel="nofollow">Need some help?</a>
- * Version: 2.0-beta
+ * Version: 2.1-alpha
  * Author: Automattic
  * Author URI: http://vaultpress.com/?utm_source=author-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * License: GPL2+
@@ -17,7 +17,7 @@
 defined( 'ABSPATH' ) || die();
 
 define( 'VAULTPRESS__MINIMUM_PHP_VERSION', '5.3.2' );
-define( 'VAULTPRESS__VERSION', '2.0-beta' );
+define( 'VAULTPRESS__VERSION', '2.1-alpha' );
 define( 'VAULTPRESS__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
 /**


### PR DESCRIPTION
Update version numbers so one can use the development version of the plugin without getting any update nags.