### PR TITLE
Admin Page: do not display a dashboard link if not registered.

### DIFF
--- a/vaultpress.php
+++ b/vaultpress.php
@@ -570,7 +570,10 @@ class VaultPress {
 		if ( $this->is_localhost() ) {
 			$this->update_option( 'connection', time() );
 			$this->update_option( 'connection_error_code', 'error_localhost' );
-			$this->update_option( 'connection_error_message', 'Hostnames such as localhost or 127.0.0.1 can not be reached by vaultpress.com and will not work with the service. Sites must be publicly accessible in order to work with VaultPress.' );
+			$this->update_option(
+				'connection_error_message',
+				esc_html__( 'Hostnames such as localhost or 127.0.0.1 can not be reached by vaultpress.com and will not work with the service. Sites must be publicly accessible in order to work with VaultPress.', 'vaultpress' )
+			);
 			$this->error_notice();
 			return array( 'ui' => ob_get_clean(), 'dashboard_link' => false );
 		}
@@ -582,7 +585,7 @@ class VaultPress {
 
 		if ( ! $this->is_registered() ) {
 			$this->ui_register();
-			return array( 'ui' => ob_get_clean(), 'dashboard_link' => true );
+			return array( 'ui' => ob_get_clean(), 'dashboard_link' => false );
 		}
 
 		$status = $this->contact_service( 'status' );


### PR DESCRIPTION
Fixes #46

### To test

1. Start with a site that is connected to WordPress.com, with VaultPress configured.
2. In the VP wp-admin dashboard, click on the link to reset settings.
3. On the page that reloads, you should not see a link to the VaultPress dashboard in the header.

![image](https://user-images.githubusercontent.com/426388/60986345-2fae6d80-a337-11e9-98fd-2ca67523fa8b.png)
