### PR TITLE
Jetpack: remove call to deprecated function

### DIFF
--- a/vaultpress.php
+++ b/vaultpress.php
@@ -2901,7 +2901,6 @@ JS;
 		if ( !class_exists('Jetpack') )
 			return false;
 
-		Jetpack::load_xml_rpc_client();
 		$xml = new Jetpack_IXR_Client( array( 'user_id' => get_current_user_id() ) );
 		$xml->query( 'wpcom.getUserEmail' );
 		if ( ! $xml->isError() ) {
@@ -2915,7 +2914,6 @@ JS;
 		if ( !class_exists('Jetpack') )
 			return false;
 
-		Jetpack::load_xml_rpc_client();
 		$xml = new Jetpack_IXR_Client( array( 'user_id' => Jetpack_Options::get_option( 'master_user' ) ) );
 		$xml->query( 'vaultpress.registerSite', $already_purchased );
 		if ( ! $xml->isError() ) {

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -2898,9 +2898,15 @@ JS;
 	}
 
 	function get_jetpack_email() {
-		if ( !class_exists('Jetpack') )
+		if ( ! class_exists( 'Jetpack' ) ) {
 			return false;
-
+		}
+		
+		// For version of Jetpack prior to 7.7.
+		if ( ! class_exists( 'Jetpack_IXR_Client' ) ) {
+			Jetpack::load_xml_rpc_client();
+		}
+		
 		$xml = new Jetpack_IXR_Client( array( 'user_id' => get_current_user_id() ) );
 		$xml->query( 'wpcom.getUserEmail' );
 		if ( ! $xml->isError() ) {
@@ -2911,8 +2917,14 @@ JS;
 	}
 
 	function get_key_via_jetpack( $already_purchased = false ) {
-		if ( !class_exists('Jetpack') )
+		if ( ! class_exists( 'Jetpack' ) ) {
 			return false;
+		}
+		
+		// For version of Jetpack prior to 7.7.
+		if ( ! class_exists( 'Jetpack_IXR_Client' ) ) {
+			Jetpack::load_xml_rpc_client();
+		}
 
 		$xml = new Jetpack_IXR_Client( array( 'user_id' => Jetpack_Options::get_option( 'master_user' ) ) );
 		$xml->query( 'vaultpress.registerSite', $already_purchased );


### PR DESCRIPTION
The Jetpack IXR client is now autoloaded:
https://github.com/Automattic/jetpack/pull/13270/

That method can consequently be removed.

**It’s going to need to be improved to handle outdated versions of Jetpack too, I think**
Related discussion: p1567509349053000-slack-akismet