### PR TITLE
Unit Tests: add PHP 7.4 to the list of PHP environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
     - php: 7.0
     - php: 7.2
     - php: 7.3
+    - php: 7.4
 
 # Git clone depth
 # By default Travis CI clones repositories to a depth of 50 commits


### PR DESCRIPTION
Now that PHP 7.4 is out, let's test VaultPress against it.

### Testing Instructions

Do the tests pass? If so, it should be good to merge.