### PR TITLE
XML-RPC: avoid warnings caused by spread operator

### DIFF
--- a/class.vaultpress-ixr-ssl-client.php
+++ b/class.vaultpress-ixr-ssl-client.php
@@ -22,8 +22,14 @@ class VaultPress_IXR_SSL_Client extends IXR_Client {
 		if ( $port )
 			$this->port = $port;
 	}
-	function query() {
-		$args = func_get_args();
+	/**
+	 * Perform the IXR request.
+	 *
+	 * @param string[] ...$args IXR args.
+	 *
+	 * @return bool True if request succeeded, false otherwise.
+	 */
+	function query( ...$args ) {
 		$method = array_shift($args);
 		$request = new IXR_Request($method, $args);
 		$length = $request->getLength();


### PR DESCRIPTION
Fixes #94

Core recently started using the spread operator in the IXR_Client class. Since VaultPress extends that class, we must follow suit and switch to using the spread operator as well.

Since VaultPress requires PHP 5.6+ (like Core), this shouldn't be an issue.