### PR TITLE
Packages: update Automattic packages to latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	},
 	"require": {
 		"automattic/jetpack-logo": "1.3.0",
-		"automattic/jetpack-autoloader": "2.0.0"
+		"automattic/jetpack-autoloader": "2.0.1"
 	},
 	"require-dev": {
 		"automattic/jetpack-standards": "master-dev"

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
 		"issues": "https://github.com/Automattic/vaultpress/issues"
 	},
 	"require": {
-		"automattic/jetpack-logo": "1.2.0",
-		"automattic/jetpack-autoloader": "1.7.0"
+		"automattic/jetpack-logo": "1.3.0",
+		"automattic/jetpack-autoloader": "2.0.0"
 	},
 	"require-dev": {
 		"automattic/jetpack-standards": "master-dev"

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	},
 	"require": {
 		"automattic/jetpack-logo": "1.3.0",
-		"automattic/jetpack-autoloader": "2.0.1"
+		"automattic/jetpack-autoloader": "2.0.2"
 	},
 	"require-dev": {
 		"automattic/jetpack-standards": "master-dev"

--- a/composer.lock
+++ b/composer.lock
@@ -4,24 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a720c25382384216d9c090712cf86d48",
+    "content-hash": "450a31330a426f5b510ad44bc426eb9a",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v1.7.0",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "7c6736eeee0f9fc49fa691fe3e958725efb27ca0"
+                "reference": "03f58e8f435724744578c1e19f7cebbf0c587356"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/7c6736eeee0f9fc49fa691fe3e958725efb27ca0",
-                "reference": "7c6736eeee0f9fc49fa691fe3e958725efb27ca0",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/03f58e8f435724744578c1e19f7cebbf0c587356",
+                "reference": "03f58e8f435724744578c1e19f7cebbf0c587356",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.1"
+                "composer-plugin-api": "^1.1 || ^2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
@@ -40,20 +40,20 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
-            "time": "2020-04-23T02:28:37+00:00"
+            "time": "2020-06-29T16:39:00+00:00"
         },
         {
             "name": "automattic/jetpack-logo",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-logo.git",
-                "reference": "d7840f25d7836ab69de979bcb67e8190220e53a3"
+                "reference": "cd0481713ace5acb3162153fab9182497d04f268"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-logo/zipball/d7840f25d7836ab69de979bcb67e8190220e53a3",
-                "reference": "d7840f25d7836ab69de979bcb67e8190220e53a3",
+                "url": "https://api.github.com/repos/Automattic/jetpack-logo/zipball/cd0481713ace5acb3162153fab9182497d04f268",
+                "reference": "cd0481713ace5acb3162153fab9182497d04f268",
                 "shasum": ""
             },
             "require-dev": {
@@ -71,7 +71,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "A logo for Jetpack",
-            "time": "2020-03-27T21:57:58+00:00"
+            "time": "2020-06-22T11:37:52+00:00"
         }
     ],
     "packages-dev": [
@@ -180,16 +180,16 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.3.4",
+            "version": "9.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "1f37659196e4f3113ea506a7efba201c52303bf1"
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/1f37659196e4f3113ea506a7efba201c52303bf1",
-                "reference": "1f37659196e4f3113ea506a7efba201c52303bf1",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
                 "shasum": ""
             },
             "require": {
@@ -234,7 +234,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-11-15T04:12:02+00:00"
+            "time": "2019-12-27T09:44:58+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
@@ -387,16 +387,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.3",
+            "version": "3.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb"
+                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
-                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
                 "shasum": ""
             },
             "require": {
@@ -434,7 +434,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-12-04T04:46:47+00:00"
+            "time": "2020-04-17T01:09:41+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9234d95f0ae71b74de5cf56b07697117",
+    "content-hash": "98d2b162f95508609b9ad1269866dbb8",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v2.0.1",
+            "version": "v2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "415269dbc7bf4771372c28b1ea866efa4f2501bf"
+                "reference": "4502da4b2443fc1b61389cacc94c34876aca2b3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/415269dbc7bf4771372c28b1ea866efa4f2501bf",
-                "reference": "415269dbc7bf4771372c28b1ea866efa4f2501bf",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/4502da4b2443fc1b61389cacc94c34876aca2b3d",
+                "reference": "4502da4b2443fc1b61389cacc94c34876aca2b3d",
                 "shasum": ""
             },
             "require": {
@@ -40,7 +40,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
-            "time": "2020-07-02T09:39:59+00:00"
+            "time": "2020-07-09T13:18:38+00:00"
         },
         {
             "name": "automattic/jetpack-logo",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "450a31330a426f5b510ad44bc426eb9a",
+    "content-hash": "9234d95f0ae71b74de5cf56b07697117",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v2.0.0",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "03f58e8f435724744578c1e19f7cebbf0c587356"
+                "reference": "415269dbc7bf4771372c28b1ea866efa4f2501bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/03f58e8f435724744578c1e19f7cebbf0c587356",
-                "reference": "03f58e8f435724744578c1e19f7cebbf0c587356",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/415269dbc7bf4771372c28b1ea866efa4f2501bf",
+                "reference": "415269dbc7bf4771372c28b1ea866efa4f2501bf",
                 "shasum": ""
             },
             "require": {
@@ -40,7 +40,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
-            "time": "2020-06-29T16:39:00+00:00"
+            "time": "2020-07-02T09:39:59+00:00"
         },
         {
             "name": "automattic/jetpack-logo",


### PR DESCRIPTION
Both the Logo package and the Autoloader package have been updated. Let's update them in VaultPress as well.

I'm not quite sure why Renovate stopped automatically creating those PRs; maybe its permissions would need to be updated for this repo.