### PR TITLE
Update Autoloader to 2.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	},
 	"require": {
 		"automattic/jetpack-logo": "1.3.0",
-		"automattic/jetpack-autoloader": "2.0.2"
+		"automattic/jetpack-autoloader": "2.1.0"
 	},
 	"require-dev": {
 		"automattic/jetpack-standards": "master-dev"

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "98d2b162f95508609b9ad1269866dbb8",
+    "content-hash": "b742f3270864e6cbe8f8ffea193a4dea",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v2.0.2",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "4502da4b2443fc1b61389cacc94c34876aca2b3d"
+                "reference": "802517b3ff3010de89141d9f7c4d56aec1d21527"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/4502da4b2443fc1b61389cacc94c34876aca2b3d",
-                "reference": "4502da4b2443fc1b61389cacc94c34876aca2b3d",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/802517b3ff3010de89141d9f7c4d56aec1d21527",
+                "reference": "802517b3ff3010de89141d9f7c4d56aec1d21527",
                 "shasum": ""
             },
             "require": {
@@ -40,7 +40,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
-            "time": "2020-07-09T13:18:38+00:00"
+            "time": "2020-07-27T20:37:00+00:00"
         },
         {
             "name": "automattic/jetpack-logo",


### PR DESCRIPTION
This new version introduces a fix on Windows environments:
https://github.com/Automattic/Jetpack/pull/16595

### Testing instructions

* You should still be able to use the plugin, the logo should display nicely in the dashboard's footer.
* The plugin should load nicely when used with the Jetpack plugin.
