### PR TITLE
Check for Jetpack version before loading Jetpack XML-RPC client

### DIFF
--- a/vaultpress.php
+++ b/vaultpress.php
@@ -533,7 +533,7 @@ class VaultPress {
 		}
 	}
 
-  // show message after activation
+	// show message after activation
 	function activated_notice() {
 		if ( 'network' == $this->get_option( 'activated' ) ) {
 			$message = sprintf(
@@ -1955,7 +1955,7 @@ JS;
 					$loadavg = null;
 
 				require_once ABSPATH . '/wp-admin/includes/plugin.php';
-                                if ( function_exists( 'get_plugin_data' ) )
+																if ( function_exists( 'get_plugin_data' ) )
 					$vaultpress_response_info                  = get_plugin_data( __FILE__ );
 				else
 					$vaultpress_response_info		   = array( 'Version' => $this->plugin_version );
@@ -2995,7 +2995,7 @@ JS;
 		}
 
 		// For version of Jetpack prior to 7.7.
-		if ( ! class_exists( 'Jetpack_IXR_Client' ) ) {
+		if ( defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '7.7', '<' )  ) {
 			Jetpack::load_xml_rpc_client();
 		}
 
@@ -3014,7 +3014,7 @@ JS;
 		}
 
 		// For version of Jetpack prior to 7.7.
-		if ( ! class_exists( 'Jetpack_IXR_Client' ) ) {
+		if ( defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '7.7', '<' )  ) {
 			Jetpack::load_xml_rpc_client();
 		}
 

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -533,7 +533,7 @@ class VaultPress {
 		}
 	}
 
-	// show message after activation
+  // show message after activation
 	function activated_notice() {
 		if ( 'network' == $this->get_option( 'activated' ) ) {
 			$message = sprintf(
@@ -1955,7 +1955,7 @@ JS;
 					$loadavg = null;
 
 				require_once ABSPATH . '/wp-admin/includes/plugin.php';
-																if ( function_exists( 'get_plugin_data' ) )
+                                if ( function_exists( 'get_plugin_data' ) )
 					$vaultpress_response_info                  = get_plugin_data( __FILE__ );
 				else
 					$vaultpress_response_info		   = array( 'Version' => $this->plugin_version );

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -2995,7 +2995,7 @@ JS;
 		}
 
 		// For version of Jetpack prior to 7.7.
-		if ( defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '7.7', '<' )  ) {
+		if ( defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '7.7', '<' ) && ! class_exists( 'Jetpack_IXR_Client' ) ) {
 			Jetpack::load_xml_rpc_client();
 		}
 
@@ -3014,7 +3014,7 @@ JS;
 		}
 
 		// For version of Jetpack prior to 7.7.
-		if ( defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '7.7', '<' )  ) {
+		if ( defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '7.7', '<' ) && ! class_exists( 'Jetpack_IXR_Client' ) ) {
 			Jetpack::load_xml_rpc_client();
 		}
 


### PR DESCRIPTION
This PR updates the conditional to check for a Jetpack version before loading XML-RPC client. 

`Jetpack::load_xml_rpc_client()` was deprecated in 7.7 version, and now we would like to clean up this code in Jetpack.
Jetpack PR: https://github.com/Automattic/jetpack/pull/16434