### PR TITLE
Fix PHP 7 warnings

### DIFF
--- a/cron-tasks.php
+++ b/cron-tasks.php
@@ -11,8 +11,8 @@ function apply_filters_ref_array($tag, $args) {
 
 	// Do 'all' actions first
 	if ( isset($wp_filter['all']) ) {
-		$wp_current_filter[] = $tag;
 		$all_args = func_get_args();
+		$wp_current_filter[] = $tag;
 		_wp_call_all_hook($all_args);
 	}
 

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -3046,12 +3046,9 @@ $vaultpress = VaultPress::init();
 
 if ( isset( $_GET['vaultpress'] ) && $_GET['vaultpress'] ) {
 	if ( !function_exists( 'wp_magic_quotes' ) ) {
-		// If already slashed, strip.
-		if ( get_magic_quotes_gpc() ) {
-			$_GET    = stripslashes_deep( $_GET    );
-			$_POST   = stripslashes_deep( $_POST   );
-			$_COOKIE = stripslashes_deep( $_COOKIE );
-		}
+        $_GET    = stripslashes_deep( $_GET    );
+        $_POST   = stripslashes_deep( $_POST   );
+        $_COOKIE = stripslashes_deep( $_COOKIE );
 
 		// Escape with wpdb.
 		$_GET    = add_magic_quotes( $_GET    );

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -3046,9 +3046,9 @@ $vaultpress = VaultPress::init();
 
 if ( isset( $_GET['vaultpress'] ) && $_GET['vaultpress'] ) {
 	if ( !function_exists( 'wp_magic_quotes' ) ) {
-        $_GET    = stripslashes_deep( $_GET    );
-        $_POST   = stripslashes_deep( $_POST   );
-        $_COOKIE = stripslashes_deep( $_COOKIE );
+		$_GET    = stripslashes_deep( $_GET    );
+		$_POST   = stripslashes_deep( $_POST   );
+		$_COOKIE = stripslashes_deep( $_COOKIE );
 
 		// Escape with wpdb.
 		$_GET    = add_magic_quotes( $_GET    );


### PR DESCRIPTION
This PR is to address a couple of warnings we have regarding PHP 7 compatibility reported in this [issue](https://github.com/Automattic/vaultpress/issues/110).

There are just two small changes:

1. Remove call to the deprecated method `get_magic_quotes_gpc`. It was also unnecessary in this context because:

> WordPress ignores the built-in PHP magic quotes setting and the value of get_magic_quotes_gpc() and will always add magic quotes (even after the feature is removed from PHP in 5.4).

https://developer.wordpress.org/reference/functions/stripslashes_deep/#more-information

2. Change func_get_args call order. 
 There was a warning complaining about accessing a function argument after calling `func_get_args`. This can be an issue because:

> Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.

We weren't modifying the function argument in any way but the warning was there anyway.
