### PR TITLE
GitHub actions: add gardening action

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--- Provide a general summary of your changes in the Title above -->
+<!-- Would you like this feature to be tested by Beta testers?
+Please add testing instructions to to-test.md in a new commit as part of your PR. -->
+
+Fixes #
+
+#### Changes proposed in this Pull Request:
+<!--- Explain what functional changes your PR includes -->
+*
+
+#### Product discussion
+<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
+<!-- Make sure any changes to existing products have been discussed and agreed upon -->
+
+#### Does this pull request change what data or activity we track or use?
+<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
+<!--- Check existing Jetpack support documents for a preview of the information we need. -->
+
+#### Testing instructions:
+<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
+<!-- Please include detailed testing steps, explaining how to test your change. -->
+<!-- Bear in mind that context you working on is not obvious for everyone.  -->
+<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
+<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
+
+* Go to '..'
+*

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -1,0 +1,34 @@
+name: Repo gardening
+
+on:
+  # We need to listen to all these events to catch all scenarios
+  pull_request:
+    types: ['opened', 'synchronize', 'edited', 'closed', 'labeled']
+
+jobs:
+  repo-gardening:
+    name: 'Assign issues, Clean up labels, and notify Design when necessary'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+     - name: Checkout
+       uses: actions/checkout@v2
+
+     - name: Setup Node
+       uses: actions/setup-node@v2
+       with:
+         node-version: 12
+
+     - name: Wait for prior instances of the workflow to finish
+       uses: softprops/turnstyle@v1
+       env:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+     - name: 'Run gardening action'
+       uses: automattic/action-repo-gardening@v1
+       with:
+         github_token: ${{ secrets.GITHUB_TOKEN }}
+         slack_token: ${{ secrets.SLACK_TOKEN }}
+         slack_design_channel: ${{ secrets.SLACK_DESIGN_CHANNEL }}
+         tasks: 'assignIssues,cleanLabels,notifyDesign'

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -26,7 +26,7 @@ jobs:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
      - name: 'Run gardening action'
-       uses: automattic/action-repo-gardening@v1
+       uses: automattic/action-repo-gardening@master
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          slack_token: ${{ secrets.SLACK_TOKEN }}


### PR DESCRIPTION
Fixes #114 

#### Changes proposed in this Pull Request:

This will allow us to do a few things automatically:

- Add assignee for issues which are being worked on, and adds the "In Progress" label.
- Remove Status labels once a PR has been merged.
- Send a Slack Notification to the Design team to request feedback, based on labels applied to a PR.

For more info:
- https://github.com/Automattic/jetpack/pull/19239
- https://github.com/Automattic/action-repo-gardening

#### Product discussion

Internal reference: p3btAN-1nR-p2

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

* Check actions running on this repo: https://github.com/Automattic/vaultpress/actions
* Check the labels added to #114. 
* See the Design Input Requested label that was added to this PR after I added the Needs Design Review label, and see the matching message: p1617185707038000-slack-C0D96691V