### PR TITLE
Gardening Action: update version and enable Editorial task

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -26,7 +26,7 @@ jobs:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
      - name: 'Run gardening action'
-       uses: automattic/action-repo-gardening@master
+       uses: automattic/action-repo-gardening@v1.1
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          slack_token: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -26,7 +26,7 @@ jobs:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
      - name: 'Run gardening action'
-       uses: automattic/action-repo-gardening@v1.1
+       uses: automattic/action-repo-gardening@v1.1.0
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          slack_token: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   repo-gardening:
-    name: 'Assign issues, Clean up labels, and notify Design when necessary'
+    name: 'Assign issues, Clean up labels, and notify Design and Editorial when necessary'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -31,4 +31,5 @@ jobs:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          slack_token: ${{ secrets.SLACK_TOKEN }}
          slack_design_channel: ${{ secrets.SLACK_DESIGN_CHANNEL }}
-         tasks: 'assignIssues,cleanLabels,notifyDesign'
+         slack_editorial_channel: ${{ secrets.SLACK_EDITORIAL_CHANNEL }}
+         tasks: 'assignIssues,cleanLabels,notifyDesign,notifyEditorial'


### PR DESCRIPTION
Fixes #115

#### Changes proposed in this Pull Request:
﻿- Gardening action: switch to using a tagged version of the action
- Enable Editorial task as it may be used in this repo as well

#### Product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* See #115 to see that the action still works.
* See if labels are properly removed from this PR when it gets merged.
